### PR TITLE
use stdint to fix build on macOS

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -1,17 +1,11 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include <stdint.h>
+
 #define OUTPUT_REPORT_LEGNTH 64
 #define INPUT_REPORT_STANDARD_LEGNTH 64
 #define INPUT_REPORT_MCUIR_LENGTH 0x170
-
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
-
-typedef char int8_t;
-typedef short int16_t;
-typedef int int32_t;
 
 #pragma pack(push, 1)
 struct SubcommandBodySPIData {


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

Failed to build on macOS ARM

```
Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:41 PST 2021; root:xnu-8019.61.5~1/RELEASE_ARM64_T6000 arm64
```

Error:

```
make
Consolidate compiler generated dependencies of target joycon
[ 12%] Building C object src/CMakeFiles/joycon.dir/imu.c.o
In file included from /Users/tianyizhuang/Projects/libjoycon/src/imu.c:3:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/string.h:141:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/sys/_types/_rsize_t.h:30:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/machine/types.h:37:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/arm/types.h:55:
/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include/sys/_types/_int8_t.h:30:31: error: typedef redefinition with different types ('signed char' vs 'char')
typedef signed char           int8_t;
                              ^
/Users/tianyizhuang/Projects/libjoycon/include/types.h:12:14: note: previous definition is here
typedef char int8_t;
```

Use stdint to avoid redefinition.